### PR TITLE
Solvespace Flathub submission update

### DIFF
--- a/com.solvespace.SolveSpace.json
+++ b/com.solvespace.SolveSpace.json
@@ -243,19 +243,22 @@
             ],
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/solvespace/solvespace.git",
-                    "tag": "v3.1",
-                    "commit": "70bde63cb32a7f049fa56cbdf924e2695fcb2916",
-                    "disable-shallow-clone": true,
+                    "type": "archive",
+                    "url": "https://github.com/solvespace/solvespace/releases/download/v3.1/solvespace-3.1.tar.xz",
+                    "sha256": "34a273ce642d0c77b8f101463730ed4eade7d90cfabfe486f3e7cbf494ff132a",
                     "x-checker-data": {
                         "is-main-source": true,
                         "type": "json",
                         "url": "https://api.github.com/repos/solvespace/solvespace/releases/latest",
-                        "tag-query": ".tag_name",
-                        "version-query": "$tag | sub(\"^v\"; \"\")",
-                        "timestamp-query": ".published_at"
+                        "version-query": ".tag_name | sub(\"^v\"; \"\")",
+                        "url-query": ".assets[] | select(.name==\"solvespace-\" + $version + \".tar.xz\") | .browser_download_url"
                     }
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                      "sed -e 's/^\\(include(GetGitCommitHash)\\)/#\\1/' -e 's/^# \\(set(GIT_COMMIT_HASH\\).*/\\1 flatpak)/' -i CMakeLists.txt"
+                    ]
                 }
             ],
             "cleanup": [

--- a/com.solvespace.SolveSpace.json
+++ b/com.solvespace.SolveSpace.json
@@ -152,6 +152,10 @@
         {
             "name": "gtkmm",
             "buildsystem": "meson",
+            "config-opts": [
+              "-Dbuild-demos=false",
+              "-Dbuild-tests=false"
+            ],
             "sources": [
                 {
                     "type": "archive",

--- a/com.solvespace.SolveSpace.json
+++ b/com.solvespace.SolveSpace.json
@@ -215,7 +215,14 @@
             ]
         },
         {
-            "name": "SolveSpace",
+            "name": "solvespace",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DFLATPAK=ON",
+                "-DENABLE_CLI=OFF",
+                "-DENABLE_TESTS=OFF"
+            ],
             "sources": [
                 {
                     "type": "git",
@@ -232,13 +239,6 @@
                         "timestamp-query": ".published_at"
                     }
                 }
-            ],
-            "buildsystem": "cmake-ninja",
-            "builddir": true,
-            "config-opts": [
-                "-DFLATPAK=ON",
-                "-DENABLE_CLI=OFF",
-                "-DENABLE_TESTS=OFF"
             ]
         }
     ]

--- a/com.solvespace.SolveSpace.json
+++ b/com.solvespace.SolveSpace.json
@@ -5,11 +5,10 @@
     "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "finish-args": [
-        "// Access to display server and OpenGL ",
+        "--device=dri",
         "--share=ipc",
         "--socket=fallback-x11",
-        "--socket=wayland",
-        "--device=dri"
+        "--socket=wayland"
     ],
     "cleanup": [
         "/include",

--- a/com.solvespace.SolveSpace.json
+++ b/com.solvespace.SolveSpace.json
@@ -238,7 +238,6 @@
             "builddir": true,
             "config-opts": [
                 "-DFLATPAK=ON",
-                "-DENABLE_CLI=OFF",
                 "-DENABLE_TESTS=OFF"
             ],
             "sources": [

--- a/com.solvespace.SolveSpace.json
+++ b/com.solvespace.SolveSpace.json
@@ -2,7 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/TingPing/flatpak-manifest-schema/master/flatpak-manifest.schema",
     "app-id": "com.solvespace.SolveSpace",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "20.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "finish-args": [
         /* Access to display server and OpenGL */

--- a/com.solvespace.SolveSpace.json
+++ b/com.solvespace.SolveSpace.json
@@ -5,7 +5,7 @@
     "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "finish-args": [
-        /* Access to display server and OpenGL */
+        "// Access to display server and OpenGL ",
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",
@@ -24,7 +24,7 @@
         "/share/man",
         "/share/doc",
         "/share/aclocal",
-        /* mm-common junk */
+        "// mm-common junk",
         "/bin/mm-common-prepare",
         "/share/mm-common"
     ],
@@ -36,7 +36,12 @@
                 {
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.2.tar.xz",
-                    "sha256": "a2a99f3fa943cf662f189163ed39a2cfc19a428d906dd4f92b387d3659d1641d"
+                    "sha256": "a2a99f3fa943cf662f189163ed39a2cfc19a428d906dd4f92b387d3659d1641d",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "mm-common",
+                        "stable-only": true
+                    }
                 }
             ]
         },
@@ -49,7 +54,15 @@
                 {
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/libsigc++/2.10/libsigc%2B%2B-2.10.6.tar.xz",
-                    "sha256": "dda176dc4681bda9d5a2ac1bc55273bdd381662b7a6d49e918267d13e8774e1b"
+                    "sha256": "dda176dc4681bda9d5a2ac1bc55273bdd381662b7a6d49e918267d13e8774e1b",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "libsigc++",
+                        "stable-only": true,
+                        "versions": {
+                            "<": "3.0.0"
+                        }
+                    }
                 }
             ]
         },
@@ -60,7 +73,15 @@
                 {
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/glibmm/2.64/glibmm-2.64.5.tar.xz",
-                    "sha256": "508fc86e2c9141198aa16c225b16fd6b911917c0d3817602652844d0973ea386"
+                    "sha256": "508fc86e2c9141198aa16c225b16fd6b911917c0d3817602652844d0973ea386",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "glibmm",
+                        "stable-only": true,
+                        "versions": {
+                            "<": "2.68.0"
+                        }
+                    }
                 }
             ]
         },
@@ -73,7 +94,15 @@
                 {
                     "type": "archive",
                     "url": "https://ftp.gnome.org/pub/GNOME/sources/cairomm/1.12/cairomm-1.12.0.tar.xz",
-                    "sha256": "a54ada8394a86182525c0762e6f50db6b9212a2109280d13ec6a0b29bfd1afe6"
+                    "sha256": "a54ada8394a86182525c0762e6f50db6b9212a2109280d13ec6a0b29bfd1afe6",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "cairomm",
+                        "stable-only": true,
+                        "versions": {
+                            "<": "1.16.0"
+                        }
+                    }
                 }
             ]
         },
@@ -86,7 +115,15 @@
                 {
                     "type": "archive",
                     "url": "https://ftp.gnome.org/pub/GNOME/sources/pangomm/2.40/pangomm-2.40.2.tar.xz",
-                    "sha256": "0a97aa72513db9088ca3034af923484108746dba146e98ed76842cf858322d05"
+                    "sha256": "0a97aa72513db9088ca3034af923484108746dba146e98ed76842cf858322d05",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "pangomm",
+                        "stable-only": true,
+                        "versions": {
+                            "<": "2.48.0"
+                        }
+                    }
                 }
             ]
         },
@@ -99,7 +136,15 @@
                 {
                     "type": "archive",
                     "url": "http://ftp.gnome.org/pub/GNOME/sources/atkmm/2.28/atkmm-2.28.0.tar.xz",
-                    "sha256": "4c4cfc917fd42d3879ce997b463428d6982affa0fb660cafcc0bc2d9afcedd3a"
+                    "sha256": "4c4cfc917fd42d3879ce997b463428d6982affa0fb660cafcc0bc2d9afcedd3a",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "atkmm",
+                        "stable-only": true,
+                        "versions": {
+                            "<": "2.30.0"
+                        }
+                    }
                 }
             ]
         },
@@ -110,22 +155,35 @@
                 {
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.4.tar.xz",
-                    "sha256": "9beb71c3e90cfcfb790396b51e3f5e7169966751efd4f3ef9697114be3be6743"
+                    "sha256": "9beb71c3e90cfcfb790396b51e3f5e7169966751efd4f3ef9697114be3be6743",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "gtkmm",
+                        "stable-only": true,
+                        "versions": {
+                            "<": "4.0.0"
+                        }
+                    }
                 }
             ]
         },
         {
             "name": "libjson-c",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
             "sources": [
                 {
-                    /* 0.15-nodoc doesn't build */
                     "type": "archive",
                     "url": "https://s3.amazonaws.com/json-c_releases/releases/json-c-0.13.1-nodoc.tar.gz",
-                    "sha256": "94a26340c0785fcff4f46ff38609cf84ebcd670df0c8efd75d039cc951d80132"
+                    "sha256": "94a26340c0785fcff4f46ff38609cf84ebcd670df0c8efd75d039cc951d80132",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 1477,
+                        "stable-only": true,
+                        "url-template": "https://s3.amazonaws.com/json-c_releases/releases/json-c-$version.tar.gz"
+                    }
                 }
-            ],
-            "buildsystem": "cmake-ninja",
-            "builddir": true
+            ]
         },
         {
             "name": "SolveSpace",

--- a/com.solvespace.SolveSpace.json
+++ b/com.solvespace.SolveSpace.json
@@ -191,8 +191,17 @@
                 {
                     "type": "git",
                     "url": "https://github.com/solvespace/solvespace.git",
-                    "commit": "00533a0fb22c85293d253f998c8d6f30029061ea",
-                    "disable-shallow-clone": true
+                    "tag": "v3.1",
+                    "commit": "70bde63cb32a7f049fa56cbdf924e2695fcb2916",
+                    "disable-shallow-clone": true,
+                    "x-checker-data": {
+                        "is-main-source": true,
+                        "type": "json",
+                        "url": "https://api.github.com/repos/solvespace/solvespace/releases/latest",
+                        "tag-query": ".tag_name",
+                        "version-query": "$tag | sub(\"^v\"; \"\")",
+                        "timestamp-query": ".published_at"
+                    }
                 }
             ],
             "buildsystem": "cmake-ninja",

--- a/com.solvespace.SolveSpace.json
+++ b/com.solvespace.SolveSpace.json
@@ -12,20 +12,11 @@
     ],
     "cleanup": [
         "/include",
-        "/lib/*/include",
-        "*.a",
-        "*.la",
-        "*.m4",
-        "/lib/libslvs*.so*",
-        "/lib/libglibmm_generate_extra_defs*.so*",
-        "/share/pkgconfig",
-        "*.pc",
-        "/share/man",
-        "/share/doc",
+        "/lib/cmake",
+        "/lib/pkgconfig",
         "/share/aclocal",
-        "// mm-common junk",
-        "/bin/mm-common-prepare",
-        "/share/mm-common"
+        "/share/pkgconfig",
+        "*.la"
     ],
     "command": "solvespace",
     "modules": [
@@ -43,6 +34,12 @@
                         "stable-only": true
                     }
                 }
+            ],
+            "cleanup": [
+              "/bin",
+              "/share/doc",
+              "/share/man",
+              "/share/mm-common"
             ]
         },
         {
@@ -65,6 +62,9 @@
                         }
                     }
                 }
+            ],
+            "cleanup": [
+                "/lib/sigc++-*"
             ]
         },
         {
@@ -87,6 +87,11 @@
                         }
                     }
                 }
+            ],
+            "cleanup": [
+                "/lib/giomm-*",
+                "/lib/glibmm-*",
+                "/lib/libglibmm_generate_extra_defs-*.so*"
             ]
         },
         {
@@ -108,6 +113,9 @@
                         }
                     }
                 }
+            ],
+            "cleanup": [
+                "/lib/cairomm-*"
             ]
         },
         {
@@ -127,6 +135,9 @@
                         }
                     }
                 }
+            ],
+            "cleanup": [
+                "/lib/pangomm-*"
             ]
         },
         {
@@ -146,6 +157,9 @@
                         }
                     }
                 }
+            ],
+            "cleanup": [
+                "/lib/atkmm-*"
             ]
         },
         {
@@ -169,6 +183,10 @@
                         }
                     }
                 }
+            ],
+            "cleanup": [
+                "/lib/gdkmm-*",
+                "/lib/gtkmm-*"
             ]
         },
         {
@@ -239,6 +257,9 @@
                         "timestamp-query": ".published_at"
                     }
                 }
+            ],
+            "cleanup": [
+                "/lib/libslvs*.so*"
             ]
         }
     ]

--- a/com.solvespace.SolveSpace.json
+++ b/com.solvespace.SolveSpace.json
@@ -32,6 +32,7 @@
     "modules": [
         {
             "name": "mm-common",
+            "buildsystem": "meson",
             "sources": [
                 {
                     "type": "archive",
@@ -47,8 +48,9 @@
         },
         {
             "name": "sigc++",
+            "buildsystem": "meson",
             "config-opts": [
-                "--disable-documentation"
+                "-Dbuild-examples=false"
             ],
             "sources": [
                 {
@@ -69,6 +71,9 @@
         {
             "name": "glibmm",
             "buildsystem": "meson",
+            "config-opts": [
+                "-Dbuild-examples=false"
+            ],
             "sources": [
                 {
                     "type": "archive",
@@ -108,9 +113,7 @@
         },
         {
             "name": "pangomm",
-            "config-opts": [
-                "--disable-documentation"
-            ],
+            "buildsystem": "meson",
             "sources": [
                 {
                     "type": "archive",
@@ -129,9 +132,7 @@
         },
         {
             "name": "atkmm",
-            "config-opts": [
-                "--disable-documentation"
-            ],
+            "buildsystem": "meson",
             "sources": [
                 {
                     "type": "archive",

--- a/com.solvespace.SolveSpace.json
+++ b/com.solvespace.SolveSpace.json
@@ -197,6 +197,10 @@
             "name": "libjson-c",
             "buildsystem": "cmake-ninja",
             "builddir": true,
+            "config-opts": [
+              "-DBUILD_STATIC_LIBS=OFF",
+              "-DENABLE_THREADING=ON"
+            ],
             "sources": [
                 {
                     "type": "archive",

--- a/com.solvespace.SolveSpace.json
+++ b/com.solvespace.SolveSpace.json
@@ -168,6 +168,27 @@
             ]
         },
         {
+            "name": "eigen",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz",
+                    "sha256": "8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 13751,
+                        "stable-only": true,
+                        "url-template": "https://gitlab.com/libeigen/eigen/-/archive/$version/eigen-$version.tar.gz"
+                    }
+                }
+            ],
+            "cleanup": [
+                "*"
+            ]
+        },
+        {
             "name": "libjson-c",
             "buildsystem": "cmake-ninja",
             "builddir": true,

--- a/com.solvespace.SolveSpace.json
+++ b/com.solvespace.SolveSpace.json
@@ -35,8 +35,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.2.tar.xz",
-                    "sha256": "a2a99f3fa943cf662f189163ed39a2cfc19a428d906dd4f92b387d3659d1641d",
+                    "url": "https://download.gnome.org/sources/mm-common/1.0/mm-common-1.0.4.tar.xz",
+                    "sha256": "e954c09b4309a7ef93e13b69260acdc5738c907477eb381b78bb1e414ee6dbd8",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "mm-common",
@@ -53,8 +53,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libsigc++/2.10/libsigc%2B%2B-2.10.6.tar.xz",
-                    "sha256": "dda176dc4681bda9d5a2ac1bc55273bdd381662b7a6d49e918267d13e8774e1b",
+                    "url": "https://download.gnome.org/sources/libsigc++/2.10/libsigc++-2.10.8.tar.xz",
+                    "sha256": "235a40bec7346c7b82b6a8caae0456353dc06e71f14bc414bcc858af1838719a",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "libsigc++",
@@ -72,8 +72,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/glibmm/2.64/glibmm-2.64.5.tar.xz",
-                    "sha256": "508fc86e2c9141198aa16c225b16fd6b911917c0d3817602652844d0973ea386",
+                    "url": "https://download.gnome.org/sources/glibmm/2.66/glibmm-2.66.4.tar.xz",
+                    "sha256": "199ace5682d81b15a1d565480b4a950682f2db6402c8aa5dd7217d71edff81d5",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "glibmm",
@@ -93,7 +93,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ftp.gnome.org/pub/GNOME/sources/cairomm/1.12/cairomm-1.12.0.tar.xz",
+                    "url": "https://download.gnome.org/sources/cairomm/1.12/cairomm-1.12.0.tar.xz",
                     "sha256": "a54ada8394a86182525c0762e6f50db6b9212a2109280d13ec6a0b29bfd1afe6",
                     "x-checker-data": {
                         "type": "gnome",
@@ -114,8 +114,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://ftp.gnome.org/pub/GNOME/sources/pangomm/2.40/pangomm-2.40.2.tar.xz",
-                    "sha256": "0a97aa72513db9088ca3034af923484108746dba146e98ed76842cf858322d05",
+                    "url": "https://download.gnome.org/sources/pangomm/2.46/pangomm-2.46.2.tar.xz",
+                    "sha256": "57442ab4dc043877bfe3839915731ab2d693fc6634a71614422fb530c9eaa6f4",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "pangomm",
@@ -135,8 +135,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/atkmm/2.28/atkmm-2.28.0.tar.xz",
-                    "sha256": "4c4cfc917fd42d3879ce997b463428d6982affa0fb660cafcc0bc2d9afcedd3a",
+                    "url": "https://download.gnome.org/sources/atkmm/2.28/atkmm-2.28.2.tar.xz",
+                    "sha256": "a0bb49765ceccc293ab2c6735ba100431807d384ffa14c2ebd30e07993fd2fa4",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "atkmm",
@@ -154,8 +154,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.4.tar.xz",
-                    "sha256": "9beb71c3e90cfcfb790396b51e3f5e7169966751efd4f3ef9697114be3be6743",
+                    "url": "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.6.tar.xz",
+                    "sha256": "4b3e142e944e1633bba008900605c341a93cfd755a7fa2a00b05d041341f11d6",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "gtkmm",
@@ -174,8 +174,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://s3.amazonaws.com/json-c_releases/releases/json-c-0.13.1-nodoc.tar.gz",
-                    "sha256": "94a26340c0785fcff4f46ff38609cf84ebcd670df0c8efd75d039cc951d80132",
+                    "url": "https://s3.amazonaws.com/json-c_releases/releases/json-c-0.16.tar.gz",
+                    "sha256": "8e45ac8f96ec7791eaf3bb7ee50e9c2100bbbc87b8d0f1d030c5ba8a0288d96b",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 1477,

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "require-important-update": true
+}


### PR DESCRIPTION
I tried to limit the number of changes in each commit for better documenting the reason for the change.

**Notable changes**

- Update runtime to 21.08
- Add [f-e-d-c](https://github.com/flathub/flatpak-external-data-checker/) support for auto-creation of update PR by flathubbot.
It's in important only mode, meaning only when SolveSpace has a new release a PR will be created, and the versions of the outdated modules (dependencies) will be bumped.
* Use meson where possible. It's much faster than autotools.
* Move module-specific cleanup array values from the global array to module-specific arrays. 
* solvespace: Cosmetics
The sources array is usually at the end of a module.
Maybe nitpicking, but the module name will be used as a folder name, and camelcase for folder names is less common on Linux. 
* solvespace: Switch to archive source
This allows offline building with cached sources.
Also, the tarball cache check is much faster than the git check, so flatpak-builder starts building much quicker.
